### PR TITLE
Todo & Category CRUD 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,10 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	compileOnly 'org.projectlombok:lombok'
+	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/src/main/java/org/onesentence/onesentence/domain/category/controller/CategoryController.java
+++ b/src/main/java/org/onesentence/onesentence/domain/category/controller/CategoryController.java
@@ -1,0 +1,31 @@
+package org.onesentence.onesentence.domain.category.controller;
+
+import jakarta.validation.Valid;
+import java.net.URI;
+import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import lombok.Value;
+import org.onesentence.onesentence.domain.category.dto.CategoryRequest;
+import org.onesentence.onesentence.domain.category.service.CategoryService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/categories")
+public class CategoryController {
+
+	private final CategoryService categoryService;
+
+
+	@PostMapping
+	public ResponseEntity<String> createCategory(@Valid @RequestBody CategoryRequest request) {
+
+		Long categoryId = categoryService.createCategory(request);
+
+		return ResponseEntity.created(URI.create("/api/v1/categories/" + categoryId)).build();
+	}
+}

--- a/src/main/java/org/onesentence/onesentence/domain/category/controller/CategoryController.java
+++ b/src/main/java/org/onesentence/onesentence/domain/category/controller/CategoryController.java
@@ -1,17 +1,11 @@
 package org.onesentence.onesentence.domain.category.controller;
 
-import jakarta.validation.Valid;
 import java.net.URI;
-import lombok.AllArgsConstructor;
 import lombok.RequiredArgsConstructor;
-import lombok.Value;
 import org.onesentence.onesentence.domain.category.dto.CategoryRequest;
 import org.onesentence.onesentence.domain.category.service.CategoryService;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -27,5 +21,14 @@ public class CategoryController {
 		Long categoryId = categoryService.createCategory(request);
 
 		return ResponseEntity.created(URI.create("/api/v1/categories/" + categoryId)).build();
+	}
+
+	@PutMapping("/{categoryId}")
+	public ResponseEntity<String> updateCategory(@RequestBody CategoryRequest request,
+		@PathVariable Long categoryId) {
+
+		Long updatedCategoryId = categoryService.updateCategory(request, categoryId);
+
+		return ResponseEntity.created(URI.create("/api/v1/categories/" + updatedCategoryId)).build();
 	}
 }

--- a/src/main/java/org/onesentence/onesentence/domain/category/controller/CategoryController.java
+++ b/src/main/java/org/onesentence/onesentence/domain/category/controller/CategoryController.java
@@ -2,6 +2,7 @@ package org.onesentence.onesentence.domain.category.controller;
 
 import java.net.URI;
 import lombok.RequiredArgsConstructor;
+import org.apache.coyote.Response;
 import org.onesentence.onesentence.domain.category.dto.CategoryRequest;
 import org.onesentence.onesentence.domain.category.service.CategoryService;
 import org.springframework.http.ResponseEntity;
@@ -30,5 +31,13 @@ public class CategoryController {
 		Long updatedCategoryId = categoryService.updateCategory(request, categoryId);
 
 		return ResponseEntity.created(URI.create("/api/v1/categories/" + updatedCategoryId)).build();
+	}
+
+	@DeleteMapping("/{categoryId}")
+	public ResponseEntity<Void> deleteCategory(@PathVariable Long categoryId) {
+
+		categoryService.deleteCategory(categoryId);
+
+		return ResponseEntity.ok().build();
 	}
 }

--- a/src/main/java/org/onesentence/onesentence/domain/category/controller/CategoryController.java
+++ b/src/main/java/org/onesentence/onesentence/domain/category/controller/CategoryController.java
@@ -22,7 +22,7 @@ public class CategoryController {
 
 
 	@PostMapping
-	public ResponseEntity<String> createCategory(@Valid @RequestBody CategoryRequest request) {
+	public ResponseEntity<String> createCategory(@RequestBody CategoryRequest request) {
 
 		Long categoryId = categoryService.createCategory(request);
 

--- a/src/main/java/org/onesentence/onesentence/domain/category/dto/CategoryRequest.java
+++ b/src/main/java/org/onesentence/onesentence/domain/category/dto/CategoryRequest.java
@@ -1,0 +1,10 @@
+package org.onesentence.onesentence.domain.category.dto;
+
+import lombok.Getter;
+
+@Getter
+public class CategoryRequest {
+
+	private String category;
+
+}

--- a/src/main/java/org/onesentence/onesentence/domain/category/dto/CategoryResponse.java
+++ b/src/main/java/org/onesentence/onesentence/domain/category/dto/CategoryResponse.java
@@ -1,0 +1,23 @@
+package org.onesentence.onesentence.domain.category.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.onesentence.onesentence.domain.category.entity.Category;
+
+@Getter
+@AllArgsConstructor
+public class CategoryResponse {
+
+	private Long categoryId;
+
+	private String category;
+
+	public CategoryResponse from(Category category) {
+		return new CategoryResponse(
+			category.getId(),
+			category.getCategory()
+		);
+	}
+
+}

--- a/src/main/java/org/onesentence/onesentence/domain/category/entity/Category.java
+++ b/src/main/java/org/onesentence/onesentence/domain/category/entity/Category.java
@@ -23,4 +23,8 @@ public class Category {
 	public Category(CategoryRequest request) {
 		this.category = request.getCategory();
 	}
+
+	public void updateCategory(CategoryRequest request) {
+		this.category = request.getCategory();
+	}
 }

--- a/src/main/java/org/onesentence/onesentence/domain/category/entity/Category.java
+++ b/src/main/java/org/onesentence/onesentence/domain/category/entity/Category.java
@@ -1,0 +1,26 @@
+package org.onesentence.onesentence.domain.category.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.onesentence.onesentence.domain.category.dto.CategoryRequest;
+
+@Entity
+@Getter
+@Table(name = "category")
+@NoArgsConstructor
+@AllArgsConstructor
+public class Category {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column
+	private String category;
+
+	public Category(CategoryRequest request) {
+		this.category = request.getCategory();
+	}
+}

--- a/src/main/java/org/onesentence/onesentence/domain/category/repository/CategoryJpaRepository.java
+++ b/src/main/java/org/onesentence/onesentence/domain/category/repository/CategoryJpaRepository.java
@@ -1,0 +1,8 @@
+package org.onesentence.onesentence.domain.category.repository;
+
+import org.onesentence.onesentence.domain.category.entity.Category;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CategoryJpaRepository extends JpaRepository<Category, Long> {
+
+}

--- a/src/main/java/org/onesentence/onesentence/domain/category/service/CategoryService.java
+++ b/src/main/java/org/onesentence/onesentence/domain/category/service/CategoryService.java
@@ -1,0 +1,8 @@
+package org.onesentence.onesentence.domain.category.service;
+
+import org.onesentence.onesentence.domain.category.dto.CategoryRequest;
+
+public interface CategoryService {
+
+	Long createCategory(CategoryRequest request);
+}

--- a/src/main/java/org/onesentence/onesentence/domain/category/service/CategoryService.java
+++ b/src/main/java/org/onesentence/onesentence/domain/category/service/CategoryService.java
@@ -10,4 +10,6 @@ public interface CategoryService {
 	Long updateCategory(CategoryRequest request, Long categoryId);
 
 	Category findById(Long categoryId);
+
+	void deleteCategory(Long categoryId);
 }

--- a/src/main/java/org/onesentence/onesentence/domain/category/service/CategoryService.java
+++ b/src/main/java/org/onesentence/onesentence/domain/category/service/CategoryService.java
@@ -1,8 +1,13 @@
 package org.onesentence.onesentence.domain.category.service;
 
 import org.onesentence.onesentence.domain.category.dto.CategoryRequest;
+import org.onesentence.onesentence.domain.category.entity.Category;
 
 public interface CategoryService {
 
 	Long createCategory(CategoryRequest request);
+
+	Long updateCategory(CategoryRequest request, Long categoryId);
+
+	Category findById(Long categoryId);
 }

--- a/src/main/java/org/onesentence/onesentence/domain/category/service/CategoryServiceImpl.java
+++ b/src/main/java/org/onesentence/onesentence/domain/category/service/CategoryServiceImpl.java
@@ -1,11 +1,10 @@
 package org.onesentence.onesentence.domain.category.service;
 
-import jakarta.persistence.Table;
-import lombok.AllArgsConstructor;
 import lombok.RequiredArgsConstructor;
 import org.onesentence.onesentence.domain.category.dto.CategoryRequest;
 import org.onesentence.onesentence.domain.category.entity.Category;
 import org.onesentence.onesentence.domain.category.repository.CategoryJpaRepository;
+import org.onesentence.onesentence.global.exception.ExceptionStatus;
 import org.onesentence.onesentence.global.exception.NotFoundException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -36,6 +35,14 @@ public class CategoryServiceImpl implements CategoryService{
 
 	@Override
 	public Category findById(Long categoryId) {
-		return categoryJpaRepository.findById(categoryId).orElseThrow(() -> new NotFoundException());
+		return categoryJpaRepository.findById(categoryId).orElseThrow(() -> new NotFoundException(
+			ExceptionStatus.NOT_FOUND));
+	}
+
+	@Override
+	@Transactional
+	public void deleteCategory(Long categoryId) {
+		Category category = findById(categoryId);
+		categoryJpaRepository.delete(category);
 	}
 }

--- a/src/main/java/org/onesentence/onesentence/domain/category/service/CategoryServiceImpl.java
+++ b/src/main/java/org/onesentence/onesentence/domain/category/service/CategoryServiceImpl.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 import org.onesentence.onesentence.domain.category.dto.CategoryRequest;
 import org.onesentence.onesentence.domain.category.entity.Category;
 import org.onesentence.onesentence.domain.category.repository.CategoryJpaRepository;
+import org.onesentence.onesentence.global.exception.NotFoundException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -22,5 +23,19 @@ public class CategoryServiceImpl implements CategoryService{
 		Category savedCategory = categoryJpaRepository.save(category);
 
 		return savedCategory.getId();
+	}
+
+	@Override
+	@Transactional
+	public Long updateCategory(CategoryRequest request, Long categoryId) {
+		Category category = findById(categoryId);
+		category.updateCategory(request);
+
+		return category.getId();
+	}
+
+	@Override
+	public Category findById(Long categoryId) {
+		return categoryJpaRepository.findById(categoryId).orElseThrow(() -> new NotFoundException());
 	}
 }

--- a/src/main/java/org/onesentence/onesentence/domain/category/service/CategoryServiceImpl.java
+++ b/src/main/java/org/onesentence/onesentence/domain/category/service/CategoryServiceImpl.java
@@ -1,0 +1,26 @@
+package org.onesentence.onesentence.domain.category.service;
+
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import org.onesentence.onesentence.domain.category.dto.CategoryRequest;
+import org.onesentence.onesentence.domain.category.entity.Category;
+import org.onesentence.onesentence.domain.category.repository.CategoryJpaRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class CategoryServiceImpl implements CategoryService{
+
+	private final CategoryJpaRepository categoryJpaRepository;
+
+	@Override
+	@Transactional
+	public Long createCategory(CategoryRequest request) {
+		Category category = new Category(request);
+		Category savedCategory = categoryJpaRepository.save(category);
+
+		return savedCategory.getId();
+	}
+}

--- a/src/main/java/org/onesentence/onesentence/domain/todo/controller/TodoController.java
+++ b/src/main/java/org/onesentence/onesentence/domain/todo/controller/TodoController.java
@@ -4,6 +4,7 @@ import java.net.URI;
 import lombok.RequiredArgsConstructor;
 import org.apache.coyote.Response;
 import org.onesentence.onesentence.domain.todo.dto.TodoRequest;
+import org.onesentence.onesentence.domain.todo.dto.TodoStatusRequest;
 import org.onesentence.onesentence.domain.todo.service.TodoService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -34,6 +35,13 @@ public class TodoController {
 		todoService.deleteTodo(todoId);
 
 		return ResponseEntity.ok().build();
+	}
+
+	@PatchMapping("/{todoId}")
+	public ResponseEntity<String> updateStauts(@RequestBody TodoStatusRequest request, @PathVariable Long todoId) {
+		Long updatedTodoId = todoService.updateStatus(request, todoId);
+
+		return ResponseEntity.created(URI.create("/api/v1/todos/" + todoId)).build();
 	}
 
 }

--- a/src/main/java/org/onesentence/onesentence/domain/todo/controller/TodoController.java
+++ b/src/main/java/org/onesentence/onesentence/domain/todo/controller/TodoController.java
@@ -2,13 +2,11 @@ package org.onesentence.onesentence.domain.todo.controller;
 
 import java.net.URI;
 import lombok.RequiredArgsConstructor;
+import org.apache.coyote.Response;
 import org.onesentence.onesentence.domain.todo.dto.TodoRequest;
 import org.onesentence.onesentence.domain.todo.service.TodoService;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -20,6 +18,13 @@ public class TodoController {
 	@PostMapping
 	public ResponseEntity<String> createTodo(@RequestBody TodoRequest request) {
 		Long todoId = todoService.createTodo(request);
+
+		return ResponseEntity.created(URI.create("/api/v1/todos/" + todoId)).build();
+	}
+
+	@PutMapping
+	public ResponseEntity<String> updateTodo(@RequestBody TodoRequest request, @PathVariable Long todoId) {
+		Long updatedTodoId = todoService.updateTodo(request, todoId);
 
 		return ResponseEntity.created(URI.create("/api/v1/todos/" + todoId)).build();
 	}

--- a/src/main/java/org/onesentence/onesentence/domain/todo/controller/TodoController.java
+++ b/src/main/java/org/onesentence/onesentence/domain/todo/controller/TodoController.java
@@ -1,0 +1,10 @@
+package org.onesentence.onesentence.domain.todo.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class TodoController {
+
+}

--- a/src/main/java/org/onesentence/onesentence/domain/todo/controller/TodoController.java
+++ b/src/main/java/org/onesentence/onesentence/domain/todo/controller/TodoController.java
@@ -1,10 +1,27 @@
 package org.onesentence.onesentence.domain.todo.controller;
 
+import java.net.URI;
 import lombok.RequiredArgsConstructor;
+import org.onesentence.onesentence.domain.todo.dto.TodoRequest;
+import org.onesentence.onesentence.domain.todo.service.TodoService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("/api/v1/todos")
 public class TodoController {
+
+	private final TodoService todoService;
+
+	@PostMapping
+	public ResponseEntity<String> createTodo(@RequestBody TodoRequest request) {
+		Long todoId = todoService.createTodo(request);
+
+		return ResponseEntity.created(URI.create("/api/v1/todos/" + todoId)).build();
+	}
 
 }

--- a/src/main/java/org/onesentence/onesentence/domain/todo/controller/TodoController.java
+++ b/src/main/java/org/onesentence/onesentence/domain/todo/controller/TodoController.java
@@ -1,10 +1,13 @@
 package org.onesentence.onesentence.domain.todo.controller;
 
 import java.net.URI;
+import java.time.LocalDate;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.apache.coyote.Response;
 import org.onesentence.onesentence.domain.todo.dto.TodoRequest;
+import org.onesentence.onesentence.domain.todo.dto.TodoResponse;
 import org.onesentence.onesentence.domain.todo.dto.TodoStatusRequest;
+import org.onesentence.onesentence.domain.todo.entity.TodoStatus;
 import org.onesentence.onesentence.domain.todo.service.TodoService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -38,10 +41,44 @@ public class TodoController {
 	}
 
 	@PatchMapping("/{todoId}")
-	public ResponseEntity<String> updateStauts(@RequestBody TodoStatusRequest request, @PathVariable Long todoId) {
+	public ResponseEntity<String> updateStatus(@RequestBody TodoStatusRequest request, @PathVariable Long todoId) {
 		Long updatedTodoId = todoService.updateStatus(request, todoId);
 
 		return ResponseEntity.created(URI.create("/api/v1/todos/" + todoId)).build();
 	}
 
+	@GetMapping("/{todoId}")
+	public ResponseEntity<TodoResponse> getTodo(@PathVariable Long todoId) {
+		TodoResponse response = todoService.getTodo(todoId);
+
+		return ResponseEntity.ok().body(response);
+	}
+
+	@GetMapping("/statuses")
+	public ResponseEntity<List<TodoResponse>> getTodosByStatus(@RequestParam TodoStatus status) {
+		List<TodoResponse> todoResponses = todoService.getTodosByStatus(status);
+
+		return ResponseEntity.ok().body(todoResponses);
+	}
+
+	@GetMapping("/dates")
+	public ResponseEntity<List<TodoResponse>> getTodosByDate(@RequestParam LocalDate date) {
+		List<TodoResponse> todoResponses = todoService.getTodosByDate(date);
+
+		return ResponseEntity.ok().body(todoResponses);
+	}
+
+	@GetMapping("/categories/{categoryId}")
+	public ResponseEntity<List<TodoResponse>> getTodosByCategory(@PathVariable Long categoryId) {
+		List<TodoResponse> todoResponses = todoService.getTodosByCategory(categoryId);
+
+		return ResponseEntity.ok().body(todoResponses);
+	}
+
+	@GetMapping()
+	public ResponseEntity<List<TodoResponse>> getTodos() {
+		List<TodoResponse> todoResponses = todoService.getTodos();
+
+		return ResponseEntity.ok().body(todoResponses);
+	}
 }

--- a/src/main/java/org/onesentence/onesentence/domain/todo/controller/TodoController.java
+++ b/src/main/java/org/onesentence/onesentence/domain/todo/controller/TodoController.java
@@ -22,11 +22,18 @@ public class TodoController {
 		return ResponseEntity.created(URI.create("/api/v1/todos/" + todoId)).build();
 	}
 
-	@PutMapping
+	@PutMapping("/{todoId}")
 	public ResponseEntity<String> updateTodo(@RequestBody TodoRequest request, @PathVariable Long todoId) {
 		Long updatedTodoId = todoService.updateTodo(request, todoId);
 
 		return ResponseEntity.created(URI.create("/api/v1/todos/" + todoId)).build();
+	}
+
+	@DeleteMapping("/{todoId}")
+	public ResponseEntity<Void> deleteTodo(@PathVariable Long todoId) {
+		todoService.deleteTodo(todoId);
+
+		return ResponseEntity.ok().build();
 	}
 
 }

--- a/src/main/java/org/onesentence/onesentence/domain/todo/dto/TodoRequest.java
+++ b/src/main/java/org/onesentence/onesentence/domain/todo/dto/TodoRequest.java
@@ -1,0 +1,21 @@
+package org.onesentence.onesentence.domain.todo.dto;
+
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+@Getter
+@NoArgsConstructor
+public class TodoRequest {
+
+	@NotNull
+	private String title;
+
+	private LocalDateTime date;
+
+	private LocalDateTime due;
+
+	private Long categoryId;
+
+	private Long colorId;
+}

--- a/src/main/java/org/onesentence/onesentence/domain/todo/dto/TodoRequest.java
+++ b/src/main/java/org/onesentence/onesentence/domain/todo/dto/TodoRequest.java
@@ -4,14 +4,17 @@ import jakarta.validation.constraints.NotNull;
 import java.time.LocalDateTime;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.onesentence.onesentence.domain.todo.entity.Path;
+
 @Getter
 @NoArgsConstructor
 public class TodoRequest {
 
-	@NotNull
 	private String title;
 
 	private LocalDateTime date;
+
+	private Path path;
 
 	private LocalDateTime due;
 

--- a/src/main/java/org/onesentence/onesentence/domain/todo/dto/TodoResponse.java
+++ b/src/main/java/org/onesentence/onesentence/domain/todo/dto/TodoResponse.java
@@ -1,0 +1,42 @@
+package org.onesentence.onesentence.domain.todo.dto;
+
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.onesentence.onesentence.domain.todo.entity.Path;
+import org.onesentence.onesentence.domain.todo.entity.Todo;
+import org.onesentence.onesentence.domain.todo.entity.TodoStatus;
+
+@Getter
+@AllArgsConstructor
+public class TodoResponse {
+
+	private Long todoId;
+
+	private String title;
+
+	private LocalDateTime date;
+
+	private Path path;
+
+	private LocalDateTime due;
+
+	private Long categoryId;
+
+	private Long colorId;
+
+	private TodoStatus status;
+
+	public TodoResponse from(Todo todo) {
+		return new TodoResponse(
+			todo.getId(),
+			todo.getTitle(),
+			todo.getDate(),
+			todo.getPath(),
+			todo.getDue(),
+			todo.getCategoryId(),
+			todo.getColorId(),
+			todo.getStatus()
+		);
+	}
+}

--- a/src/main/java/org/onesentence/onesentence/domain/todo/dto/TodoResponse.java
+++ b/src/main/java/org/onesentence/onesentence/domain/todo/dto/TodoResponse.java
@@ -27,7 +27,7 @@ public class TodoResponse {
 
 	private TodoStatus status;
 
-	public TodoResponse from(Todo todo) {
+	public static TodoResponse from(Todo todo) {
 		return new TodoResponse(
 			todo.getId(),
 			todo.getTitle(),

--- a/src/main/java/org/onesentence/onesentence/domain/todo/dto/TodoStatusRequest.java
+++ b/src/main/java/org/onesentence/onesentence/domain/todo/dto/TodoStatusRequest.java
@@ -1,0 +1,12 @@
+package org.onesentence.onesentence.domain.todo.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class TodoStatusRequest {
+
+	private String status;
+
+}

--- a/src/main/java/org/onesentence/onesentence/domain/todo/entity/Path.java
+++ b/src/main/java/org/onesentence/onesentence/domain/todo/entity/Path.java
@@ -1,0 +1,8 @@
+package org.onesentence.onesentence.domain.todo.entity;
+
+import lombok.Getter;
+
+@Getter
+public enum Path {
+	VOICE, TEXT, DIRECT
+}

--- a/src/main/java/org/onesentence/onesentence/domain/todo/entity/Todo.java
+++ b/src/main/java/org/onesentence/onesentence/domain/todo/entity/Todo.java
@@ -7,6 +7,7 @@ import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.onesentence.onesentence.domain.todo.dto.TodoRequest;
 
 @Getter
 @Entity
@@ -40,12 +41,12 @@ public class Todo {
 	@Column
 	private TodoStatus status;
 
-	public Todo(String title, LocalDateTime date, Path path, Long categoryId, Long colorId) {
-		this.title = title;
-		this.date = date;
-		this.path = path;
-		this.categoryId = categoryId;
-		this.colorId = colorId;
+	public Todo(TodoRequest request) {
+		this.title = request.getTitle();
+		this.date = request.getDate();
+		this.path = request.getPath();
+		this.categoryId = request.getCategoryId();
+		this.colorId = request.getColorId();
 		this.status = TodoStatus.TODO;
 	}
 

--- a/src/main/java/org/onesentence/onesentence/domain/todo/entity/Todo.java
+++ b/src/main/java/org/onesentence/onesentence/domain/todo/entity/Todo.java
@@ -62,10 +62,10 @@ public class Todo {
 		this.status = TodoStatus.DONE;
 	}
 
-	public void updateTodo(String title, LocalDateTime date, Long categoryId, Long colorId) {
-		this.title = title;
-		this.date = date;
-		this.categoryId = categoryId;
-		this.colorId = colorId;
+	public void updateTodo(TodoRequest request) {
+		this.title = request.getTitle();
+		this.date = request.getDate();
+		this.categoryId = request.getCategoryId();
+		this.colorId = request.getColorId();
 	}
 }

--- a/src/main/java/org/onesentence/onesentence/domain/todo/entity/Todo.java
+++ b/src/main/java/org/onesentence/onesentence/domain/todo/entity/Todo.java
@@ -8,6 +8,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.onesentence.onesentence.domain.todo.dto.TodoRequest;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
 
 @Getter
 @Entity
@@ -48,7 +49,7 @@ public class Todo {
 		this.categoryId = request.getCategoryId();
 		this.colorId = request.getColorId();
 		this.status = TodoStatus.TODO;
-		this.due = request.getDue()
+		this.due = request.getDue();
 	}
 
 	public void changeToInProgress() {

--- a/src/main/java/org/onesentence/onesentence/domain/todo/entity/Todo.java
+++ b/src/main/java/org/onesentence/onesentence/domain/todo/entity/Todo.java
@@ -1,0 +1,70 @@
+package org.onesentence.onesentence.domain.todo.entity;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "todo")
+@NoArgsConstructor
+@AllArgsConstructor
+public class Todo {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column
+	private String title;
+
+	@Column
+	private LocalDateTime date;
+
+	@Column
+	private Path path;
+
+	@Column
+	private LocalDateTime due;
+
+	@Column
+	private Long categoryId;
+
+	@Column
+	private Long colorId;
+
+	@Column
+	private TodoStatus status;
+
+	public Todo(String title, LocalDateTime date, Path path, Long categoryId, Long colorId) {
+		this.title = title;
+		this.date = date;
+		this.path = path;
+		this.categoryId = categoryId;
+		this.colorId = colorId;
+		this.status = TodoStatus.TODO;
+	}
+
+	public void setDue(LocalDateTime due) {
+		this.date = due;
+	}
+
+	public void changeToInProgress() {
+		this.status = TodoStatus.IN_PROGRESS;
+	}
+
+	public void changeToDone() {
+		this.status = TodoStatus.DONE;
+	}
+
+	public void updateTodo(String title, LocalDateTime date, Long categoryId, Long colorId) {
+		this.title = title;
+		this.date = date;
+		this.categoryId = categoryId;
+		this.colorId = colorId;
+	}
+}

--- a/src/main/java/org/onesentence/onesentence/domain/todo/entity/Todo.java
+++ b/src/main/java/org/onesentence/onesentence/domain/todo/entity/Todo.java
@@ -48,10 +48,7 @@ public class Todo {
 		this.categoryId = request.getCategoryId();
 		this.colorId = request.getColorId();
 		this.status = TodoStatus.TODO;
-	}
-
-	public void setDue(LocalDateTime due) {
-		this.date = due;
+		this.due = request.getDue()
 	}
 
 	public void changeToInProgress() {
@@ -67,5 +64,6 @@ public class Todo {
 		this.date = request.getDate();
 		this.categoryId = request.getCategoryId();
 		this.colorId = request.getColorId();
+		this.due = request.getDue();
 	}
 }

--- a/src/main/java/org/onesentence/onesentence/domain/todo/entity/TodoStatus.java
+++ b/src/main/java/org/onesentence/onesentence/domain/todo/entity/TodoStatus.java
@@ -1,0 +1,9 @@
+package org.onesentence.onesentence.domain.todo.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+public enum TodoStatus {
+	TODO, IN_PROGRESS, DONE
+}

--- a/src/main/java/org/onesentence/onesentence/domain/todo/repository/TodoJpaRepository.java
+++ b/src/main/java/org/onesentence/onesentence/domain/todo/repository/TodoJpaRepository.java
@@ -1,0 +1,8 @@
+package org.onesentence.onesentence.domain.todo.repository;
+
+import org.onesentence.onesentence.domain.todo.entity.Todo;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TodoJpaRepository extends JpaRepository<Todo, Long> {
+
+}

--- a/src/main/java/org/onesentence/onesentence/domain/todo/repository/TodoJpaRepository.java
+++ b/src/main/java/org/onesentence/onesentence/domain/todo/repository/TodoJpaRepository.java
@@ -1,8 +1,18 @@
 package org.onesentence.onesentence.domain.todo.repository;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
 import org.onesentence.onesentence.domain.todo.entity.Todo;
+import org.onesentence.onesentence.domain.todo.entity.TodoStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface TodoJpaRepository extends JpaRepository<Todo, Long> {
+
+	List<Todo> findByStatus(TodoStatus status);
+
+	List<Todo> findByDateBetween(LocalDateTime start, LocalDateTime end);
+
+	List<Todo> findByCategoryId(Long categoryId);
 
 }

--- a/src/main/java/org/onesentence/onesentence/domain/todo/service/TodoService.java
+++ b/src/main/java/org/onesentence/onesentence/domain/todo/service/TodoService.java
@@ -1,8 +1,12 @@
 package org.onesentence.onesentence.domain.todo.service;
 
+import java.time.LocalDate;
+import java.util.List;
 import org.onesentence.onesentence.domain.todo.dto.TodoRequest;
+import org.onesentence.onesentence.domain.todo.dto.TodoResponse;
 import org.onesentence.onesentence.domain.todo.dto.TodoStatusRequest;
 import org.onesentence.onesentence.domain.todo.entity.Todo;
+import org.onesentence.onesentence.domain.todo.entity.TodoStatus;
 
 public interface TodoService {
 
@@ -15,4 +19,14 @@ public interface TodoService {
 	void deleteTodo(Long todoId);
 
 	Long updateStatus(TodoStatusRequest request, Long todoId);
+
+	TodoResponse getTodo(Long todoId);
+
+	List<TodoResponse> getTodosByStatus(TodoStatus status);
+
+	List<TodoResponse> getTodosByDate(LocalDate date);
+
+	List<TodoResponse> getTodosByCategory(Long categoryId);
+
+	List<TodoResponse> getTodos();
 }

--- a/src/main/java/org/onesentence/onesentence/domain/todo/service/TodoService.java
+++ b/src/main/java/org/onesentence/onesentence/domain/todo/service/TodoService.java
@@ -1,5 +1,8 @@
 package org.onesentence.onesentence.domain.todo.service;
 
+import org.onesentence.onesentence.domain.todo.dto.TodoRequest;
+
 public interface TodoService {
 
+	Long createTodo(TodoRequest request);
 }

--- a/src/main/java/org/onesentence/onesentence/domain/todo/service/TodoService.java
+++ b/src/main/java/org/onesentence/onesentence/domain/todo/service/TodoService.java
@@ -1,0 +1,5 @@
+package org.onesentence.onesentence.domain.todo.service;
+
+public interface TodoService {
+
+}

--- a/src/main/java/org/onesentence/onesentence/domain/todo/service/TodoService.java
+++ b/src/main/java/org/onesentence/onesentence/domain/todo/service/TodoService.java
@@ -1,8 +1,13 @@
 package org.onesentence.onesentence.domain.todo.service;
 
 import org.onesentence.onesentence.domain.todo.dto.TodoRequest;
+import org.onesentence.onesentence.domain.todo.entity.Todo;
 
 public interface TodoService {
 
 	Long createTodo(TodoRequest request);
+
+	Long updateTodo(TodoRequest request, Long todoId);
+
+	Todo findById(Long todoId);
 }

--- a/src/main/java/org/onesentence/onesentence/domain/todo/service/TodoService.java
+++ b/src/main/java/org/onesentence/onesentence/domain/todo/service/TodoService.java
@@ -1,6 +1,7 @@
 package org.onesentence.onesentence.domain.todo.service;
 
 import org.onesentence.onesentence.domain.todo.dto.TodoRequest;
+import org.onesentence.onesentence.domain.todo.dto.TodoStatusRequest;
 import org.onesentence.onesentence.domain.todo.entity.Todo;
 
 public interface TodoService {
@@ -12,4 +13,6 @@ public interface TodoService {
 	Todo findById(Long todoId);
 
 	void deleteTodo(Long todoId);
+
+	Long updateStatus(TodoStatusRequest request, Long todoId);
 }

--- a/src/main/java/org/onesentence/onesentence/domain/todo/service/TodoService.java
+++ b/src/main/java/org/onesentence/onesentence/domain/todo/service/TodoService.java
@@ -10,4 +10,6 @@ public interface TodoService {
 	Long updateTodo(TodoRequest request, Long todoId);
 
 	Todo findById(Long todoId);
+
+	void deleteTodo(Long todoId);
 }

--- a/src/main/java/org/onesentence/onesentence/domain/todo/service/TodoServiceImpl.java
+++ b/src/main/java/org/onesentence/onesentence/domain/todo/service/TodoServiceImpl.java
@@ -1,10 +1,17 @@
 package org.onesentence.onesentence.domain.todo.service;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.RequiredArgsConstructor;
 import org.onesentence.onesentence.domain.todo.dto.TodoRequest;
+import org.onesentence.onesentence.domain.todo.dto.TodoResponse;
 import org.onesentence.onesentence.domain.todo.dto.TodoStatusRequest;
 import org.onesentence.onesentence.domain.todo.entity.Todo;
+import org.onesentence.onesentence.domain.todo.entity.TodoStatus;
 import org.onesentence.onesentence.domain.todo.repository.TodoJpaRepository;
 import org.onesentence.onesentence.global.exception.ExceptionStatus;
 import org.onesentence.onesentence.global.exception.NotFoundException;
@@ -61,5 +68,71 @@ public class TodoServiceImpl implements TodoService{
 		}
 
 		return todo.getId();
+	}
+
+	@Override
+	@Transactional(readOnly = true)
+	public TodoResponse getTodo(Long todoId) {
+		Todo todo = findById(todoId);
+
+		return TodoResponse.from(todo);
+	}
+
+	@Override
+	@Transactional(readOnly = true)
+	public List<TodoResponse> getTodosByStatus(TodoStatus status) {
+		List<TodoResponse> todoResponses = new ArrayList<>();
+
+		List<Todo> todos = todoJpaRepository.findByStatus(status);
+
+		for (Todo todo : todos) {
+			todoResponses.add(TodoResponse.from(todo));
+		}
+
+		return todoResponses;
+	}
+
+	@Override
+	@Transactional(readOnly = true)
+	public List<TodoResponse> getTodosByDate(LocalDate date) {
+		List<TodoResponse> todoResponses = new ArrayList<>();
+		LocalDateTime start = date.atStartOfDay();
+		LocalDateTime end = date.atTime(LocalTime.MAX);
+
+		List<Todo> todos = todoJpaRepository.findByDateBetween(start, end);
+
+		for (Todo todo : todos) {
+			todoResponses.add(TodoResponse.from(todo));
+		}
+
+		return todoResponses;
+	}
+
+	@Override
+	@Transactional(readOnly = true)
+	public List<TodoResponse> getTodosByCategory(Long categoryId) {
+		List<TodoResponse> todoResponses = new ArrayList<>();
+
+		List<Todo> todos = todoJpaRepository.findByCategoryId(categoryId);
+
+		for (Todo todo : todos) {
+			todoResponses.add(TodoResponse.from(todo));
+		}
+
+		return todoResponses;
+	}
+
+	@Override
+	@Transactional(readOnly = true)
+	public List<TodoResponse> getTodos() {
+		List<TodoResponse> todoResponses = new ArrayList<>();
+
+		List<Todo> todos = todoJpaRepository.findAll();
+
+		for (Todo todo : todos) {
+			todoResponses.add(TodoResponse.from(todo));
+		}
+
+		return todoResponses;
 	}
 }

--- a/src/main/java/org/onesentence/onesentence/domain/todo/service/TodoServiceImpl.java
+++ b/src/main/java/org/onesentence/onesentence/domain/todo/service/TodoServiceImpl.java
@@ -1,10 +1,24 @@
 package org.onesentence.onesentence.domain.todo.service;
 
 import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import org.onesentence.onesentence.domain.todo.dto.TodoRequest;
+import org.onesentence.onesentence.domain.todo.entity.Todo;
+import org.onesentence.onesentence.domain.todo.repository.TodoJpaRepository;
 import org.springframework.stereotype.Service;
 
 @Service
-@AllArgsConstructor
+@RequiredArgsConstructor
 public class TodoServiceImpl implements TodoService{
 
+	private final TodoJpaRepository todoJpaRepository;
+
+	@Override
+	public Long createTodo(TodoRequest request) {
+
+		Todo todo = new Todo(request);
+		Todo savedTodo = todoJpaRepository.save(todo);
+
+		return savedTodo.getId();
+	}
 }

--- a/src/main/java/org/onesentence/onesentence/domain/todo/service/TodoServiceImpl.java
+++ b/src/main/java/org/onesentence/onesentence/domain/todo/service/TodoServiceImpl.java
@@ -5,7 +5,10 @@ import lombok.RequiredArgsConstructor;
 import org.onesentence.onesentence.domain.todo.dto.TodoRequest;
 import org.onesentence.onesentence.domain.todo.entity.Todo;
 import org.onesentence.onesentence.domain.todo.repository.TodoJpaRepository;
+import org.onesentence.onesentence.global.exception.ExceptionStatus;
+import org.onesentence.onesentence.global.exception.NotFoundException;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -14,11 +17,28 @@ public class TodoServiceImpl implements TodoService{
 	private final TodoJpaRepository todoJpaRepository;
 
 	@Override
+	@Transactional
 	public Long createTodo(TodoRequest request) {
 
 		Todo todo = new Todo(request);
 		Todo savedTodo = todoJpaRepository.save(todo);
 
 		return savedTodo.getId();
+	}
+
+	@Override
+	@Transactional
+	public Long updateTodo(TodoRequest request, Long todoId) {
+
+		Todo todo = findById(todoId);
+		todo.updateTodo(request);
+
+		return todo.getId();
+	}
+
+	@Override
+	public Todo findById(Long todoId) {
+		return todoJpaRepository.findById(todoId).orElseThrow(() -> new NotFoundException(
+			ExceptionStatus.NOT_FOUND));
 	}
 }

--- a/src/main/java/org/onesentence/onesentence/domain/todo/service/TodoServiceImpl.java
+++ b/src/main/java/org/onesentence/onesentence/domain/todo/service/TodoServiceImpl.java
@@ -3,6 +3,7 @@ package org.onesentence.onesentence.domain.todo.service;
 import lombok.AllArgsConstructor;
 import lombok.RequiredArgsConstructor;
 import org.onesentence.onesentence.domain.todo.dto.TodoRequest;
+import org.onesentence.onesentence.domain.todo.dto.TodoStatusRequest;
 import org.onesentence.onesentence.domain.todo.entity.Todo;
 import org.onesentence.onesentence.domain.todo.repository.TodoJpaRepository;
 import org.onesentence.onesentence.global.exception.ExceptionStatus;
@@ -47,5 +48,18 @@ public class TodoServiceImpl implements TodoService{
 	public void deleteTodo(Long todoId) {
 		Todo todo = findById(todoId);
 		todoJpaRepository.delete(todo);
+	}
+
+	@Override
+	@Transactional
+	public Long updateStatus(TodoStatusRequest request, Long todoId) {
+		Todo todo = findById(todoId);
+		if (request.getStatus().equals("진행중")) {
+			todo.changeToInProgress();
+		} else if (request.getStatus().equals("완료")) {
+			todo.changeToDone();
+		}
+
+		return todo.getId();
 	}
 }

--- a/src/main/java/org/onesentence/onesentence/domain/todo/service/TodoServiceImpl.java
+++ b/src/main/java/org/onesentence/onesentence/domain/todo/service/TodoServiceImpl.java
@@ -1,0 +1,10 @@
+package org.onesentence.onesentence.domain.todo.service;
+
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@AllArgsConstructor
+public class TodoServiceImpl implements TodoService{
+
+}

--- a/src/main/java/org/onesentence/onesentence/domain/todo/service/TodoServiceImpl.java
+++ b/src/main/java/org/onesentence/onesentence/domain/todo/service/TodoServiceImpl.java
@@ -41,4 +41,11 @@ public class TodoServiceImpl implements TodoService{
 		return todoJpaRepository.findById(todoId).orElseThrow(() -> new NotFoundException(
 			ExceptionStatus.NOT_FOUND));
 	}
+
+	@Override
+	@Transactional
+	public void deleteTodo(Long todoId) {
+		Todo todo = findById(todoId);
+		todoJpaRepository.delete(todo);
+	}
 }

--- a/src/main/java/org/onesentence/onesentence/global/exception/ApiException.java
+++ b/src/main/java/org/onesentence/onesentence/global/exception/ApiException.java
@@ -1,0 +1,15 @@
+package org.onesentence.onesentence.global.exception;
+
+import lombok.Getter;
+
+@Getter
+public abstract class ApiException extends RuntimeException {
+
+	private final Integer statusCode;
+	private final String message;
+
+	protected ApiException(ExceptionStatus ex) {
+		this.statusCode = ex.getStatusCode();
+		this.message = ex.getMessage();
+	}
+}

--- a/src/main/java/org/onesentence/onesentence/global/exception/ExceptionStatus.java
+++ b/src/main/java/org/onesentence/onesentence/global/exception/ExceptionStatus.java
@@ -1,0 +1,15 @@
+package org.onesentence.onesentence.global.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ExceptionStatus {
+
+	NOT_FOUND(HttpStatus.BAD_REQUEST.value(), "존재하지 않습니다.");
+
+	private final Integer statusCode;
+	private final String message;
+}

--- a/src/main/java/org/onesentence/onesentence/global/exception/NotFoundException.java
+++ b/src/main/java/org/onesentence/onesentence/global/exception/NotFoundException.java
@@ -1,0 +1,9 @@
+package org.onesentence.onesentence.global.exception;
+
+public class NotFoundException extends ApiException{
+
+	public NotFoundException(ExceptionStatus ex) {
+		super(ex);
+	}
+
+}


### PR DESCRIPTION
## 개요
Todo 와 Category 의 기본적인 CRUD 구현했습니다.
Todo 조회에 있어 단건조회, 전체 조회, 날짜/카테고리/상태 별 조회 구현했습니다.

## To Reviewers
1. Todo 의 상태는 TODO, IN_PROGRESS, DONE 으로만 DB에 저장할 예정입니다.
2. Todo 의 등록 경로를 path 라고 하여 VOICE(음성), TEXT(문장), DIRECT(수동) 으로 DB에 저장할 예정입니다.
3. Todo 의 상태 변경 기능에 있어 TODO 에서 IN_PROGRESS, DONE 으로 변경했다면 다시 TODO로 돌아가는 것을 고려하지 않고 구현했습니다. 

## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
